### PR TITLE
Revert "effectively disable libvirt live snapshotting"

### DIFF
--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -342,10 +342,7 @@ MIN_LIBVIRT_VERSION = (0, 9, 11)
 MIN_LIBVIRT_DEVICE_CALLBACK_VERSION = (1, 1, 1)
 # Live snapshot requirements
 REQ_HYPERVISOR_LIVESNAPSHOT = "QEMU"
-# TODO(sdague): this should be 1.0.0, but hacked to set 1.3.0 until
-# https://bugs.launchpad.net/nova/+bug/1334398
-# can be diagnosed & resolved
-MIN_LIBVIRT_LIVESNAPSHOT_VERSION = (1, 3, 0)
+MIN_LIBVIRT_LIVESNAPSHOT_VERSION = (1, 0, 0)
 MIN_QEMU_LIVESNAPSHOT_VERSION = (1, 3, 0)
 # block size tuning requirements
 MIN_LIBVIRT_BLOCKIO_VERSION = (0, 10, 2)


### PR DESCRIPTION
live snapshot functions fine in our environments, so we're reverting
this in our fork.

This reverts commit c1c159460de376a06b8479f90f42d9f62eace961.
