### PR TITLE
Backport live snapshot workaround to juno branch.

### DIFF
--- a/nova/utils.py
+++ b/nova/utils.py
@@ -77,10 +77,27 @@ utils_opts = [
     cfg.StrOpt('tempdir',
                help='Explicitly specify the temporary working directory'),
 ]
+
+""" This group is for very specific reasons.
+
+If you're:
+- Working around an issue in a system tool (e.g. libvirt or qemu) where the fix
+  is in flight/discussed in that community.
+- The tool can be/is fixed in some distributions and rather than patch the code
+  those distributions can trivially set a config option to get the "correct"
+  behavior.
+This is a good place for your workaround.
+
+Please use with care!
+Document the BugID that your workaround is paired with."""
+
+workarounds_opts = [
+    ]
 CONF = cfg.CONF
 CONF.register_opts(monkey_patch_opts)
 CONF.register_opts(utils_opts)
 CONF.import_opt('network_api_class', 'nova.network')
+CONF.register_opts(workarounds_opts, group='workarounds')
 
 LOG = logging.getLogger(__name__)
 

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -92,6 +92,13 @@ Please use with care!
 Document the BugID that your workaround is paired with."""
 
 workarounds_opts = [
+    cfg.BoolOpt('disable_libvirt_livesnapshot',
+                default=True,
+                help='When using libvirt 1.2.2 fails live snapshots '
+                     'intermittently under load.  This config option provides '
+                     'mechanism to disable livesnapshot while this is '
+                     'resolved.  See '
+                     'https://bugs.launchpad.net/nova/+bug/1334398'),
     ]
 CONF = cfg.CONF
 CONF.register_opts(monkey_patch_opts)

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -281,6 +281,7 @@ CONF.import_opt('proxyclient_address', 'nova.console.serial',
                 group='serial_console')
 CONF.import_opt('hw_disk_discard', 'nova.virt.libvirt.imagebackend',
                 group='libvirt')
+CONF.import_group('workarounds', 'nova.utils')
 
 DEFAULT_FIREWALL_DRIVER = "%s.%s" % (
     libvirt_firewall.__name__,
@@ -345,10 +346,7 @@ MIN_LIBVIRT_VERSION = (0, 9, 11)
 MIN_LIBVIRT_DEVICE_CALLBACK_VERSION = (1, 1, 1)
 # Live snapshot requirements
 REQ_HYPERVISOR_LIVESNAPSHOT = "QEMU"
-# TODO(sdague): this should be 1.0.0, but hacked to set 1.3.0 until
-# https://bugs.launchpad.net/nova/+bug/1334398
-# can be diagnosed & resolved
-MIN_LIBVIRT_LIVESNAPSHOT_VERSION = (1, 3, 0)
+MIN_LIBVIRT_LIVESNAPSHOT_VERSION = (1, 0, 0)
 MIN_QEMU_LIVESNAPSHOT_VERSION = (1, 3, 0)
 # block size tuning requirements
 MIN_LIBVIRT_BLOCKIO_VERSION = (0, 10, 2)
@@ -1670,7 +1668,8 @@ class LibvirtDriver(driver.ComputeDriver):
                                   MIN_QEMU_LIVESNAPSHOT_VERSION,
                                   REQ_HYPERVISOR_LIVESNAPSHOT)
              and source_format not in ('lvm', 'rbd')
-             and not CONF.ephemeral_storage_encryption.enabled):
+             and not CONF.ephemeral_storage_encryption.enabled
+             and not CONF.workarounds.disable_libvirt_livesnapshot):
             live_snapshot = True
             # Abort is an idempotent operation, so make sure any block
             # jobs which may have failed are ended. This operation also


### PR DESCRIPTION
Local configuration will still be necessary to enable live snapshots, this just backports the mechanism by which to feature flag it on.
